### PR TITLE
Fix node run error and improve docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 #
 # Build image: docker build -t bianjie/irita .
 #
-FROM golang:1.17.3-alpine3.14 as builder
+FROM golang:1.19.3-alpine3.17 as builder
 
-RUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.12/main/ > /etc/apk/repositories
+RUN echo -e http://mirrors.ustc.edu.cn/alpine/v3.17/main/ > /etc/apk/repositories
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
 # with some changes to support CosmWasm toolchain, etc
@@ -31,13 +31,13 @@ RUN sha256sum /lib/libwasmvm_muslc.a | grep ef294a7a53c8d0aa6a8da4b10e94fb9f053f
 
 RUN go env -w GOPROXY=https://goproxy.cn
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc make build
-
+RUN apk del $PACKAGES
 # ----------------------------
 
 FROM ubuntu:20.04
 
 # Set up dependencies
-ENV PACKAGES make gcc perl wget
+ENV PACKAGES build-essential perl wget
 
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ localnet-init:
 	@echo "Faucet key seed: tube lonely pause spring gym veteran know want grid tired taxi such same mesh charge orient bracket ozone concert once good quick dry boss"
 
 localnet-start: localnet-init localnet-stop
-	docker-compose up 
+	docker-compose up -d
 
 localnet-stop:
 	docker-compose down

--- a/doc/build.md
+++ b/doc/build.md
@@ -181,11 +181,20 @@ CRITICAL please submit the following transaction:
    tx crisis invariant-borken bank total-supply
 ```
 
-然后我发现了是SDK的这个模块的BUG，但是没追究其原因，我又看了下，感觉`go.mod`里面的sdk版本是包含了这些Fixs的。但是我本机，不在容器里面编译
-就可以在ubuntu 20.04的环境里面运行，所以我把Dockerfile里面的golang版本和ubuntu的版本都升级到跟我本机编译开发环境保持一致，
+然后我发现了是SDK的这个模块的BUG，但是没追究其原因，我又看了下，感觉`go.mod`里面的sdk版本是包含了这些Fixs的
+
+- https://github.com/cosmos/cosmos-sdk/issues/9159
+- https://github.com/cosmos/cosmos-sdk/pull/9229
+- https://github.com/cosmos/cosmos-sdk/issues/4795
+- https://github.com/cosmos/cosmos-sdk/issues/4803
+- https://github.com/cosmos/cosmos-sdk/pull/4854
+
+
+
+但是我本机，不在容器里面编译就可以在ubuntu 20.04的环境里面运行，所以我把Dockerfile里面的golang版本和ubuntu的版本都升级到跟我本机编译开发环境保持一致，
 
 最后运行docker compose的时候，节点就没有报错了，并且4个validators节点正常出块，并且同一高度的block的hash是一致的。
 
-其实Dockerfile还可以优化，直接把golang的alpine Linux版本删除，在ubuntu上构建项目，他们文昌链为什么会这样做，用Alpine Linux编译，然后拷贝到
-ubuntu上，是因为golang的官方Docker镜像就是推荐用Alpine Linux的镜像版本，而且他们想用musl编译项目，让irita的二进制全静态，不依赖任何动态库，所以
-Dockerfile里面又要下载muslc的静态库.a文件之类的，搞得很烦人。其实完全不必这么麻烦，都容器运行了，动态静态无所谓，所以可以考虑改天优化掉。
+其实Dockerfile还可以优化，直接把golang的alpine Linux版本删除，在ubuntu上构建项目，他们文昌链为什么会这样做，用Alpine Linux编译，然后拷贝到ubuntu上，是因为golang的官方Docker镜像就是推荐用Alpine Linux的镜像版本，而且他们想用musl编译项目，让irita的二进制全静态，不依赖任何动态库，所以Dockerfile里面又要下载muslc的静态库.a文件之类的，搞得很烦人。
+
+其实完全不必这么麻烦，都容器运行了，动态静态无所谓，所以可以考虑改天优化掉。

--- a/doc/build.md
+++ b/doc/build.md
@@ -169,3 +169,19 @@ openssl: error while loading shared libraries: libssl.so.3: cannot open shared o
 ```
 
 以上错误， 解决方案就是`sudo ldconfig /usr/local/lib64` https://stackoverflow.com/questions/54124906/openssl-error-while-loading-shared-libraries-libssl-so-3 
+
+## TroubleShooting
+
+之前用Docker compose运行4 validators的本地节点网络，节点内部的`crisis`模块的日志报出 `keeper.Keeper.AssetInvariants`的错误，
+
+还提示:
+
+```txt
+CRITICAL please submit the following transaction:
+   tx crisis invariant-borken bank total-supply
+```
+
+然后我发现了是SDK的这个模块的BUG，但是没追究其原因，我又看了下，感觉`go.mod`里面的sdk版本是包含了这些Fixs的。但是我本机，不在容器里面编译
+就可以在ubuntu 20.04的环境里面运行，所以我把Dockerfile里面的golang版本和ubuntu的版本都升级到跟我本机编译开发环境保持一致，
+
+最后运行docker compose的时候，节点就没有报错了，并且4个validators节点正常出块，并且同一高度的block的hash是一致的。

--- a/doc/build.md
+++ b/doc/build.md
@@ -185,3 +185,7 @@ CRITICAL please submit the following transaction:
 就可以在ubuntu 20.04的环境里面运行，所以我把Dockerfile里面的golang版本和ubuntu的版本都升级到跟我本机编译开发环境保持一致，
 
 最后运行docker compose的时候，节点就没有报错了，并且4个validators节点正常出块，并且同一高度的block的hash是一致的。
+
+其实Dockerfile还可以优化，直接把golang的alpine Linux版本删除，在ubuntu上构建项目，他们文昌链为什么会这样做，用Alpine Linux编译，然后拷贝到
+ubuntu上，是因为golang的官方Docker镜像就是推荐用Alpine Linux的镜像版本，而且他们想用musl编译项目，让irita的二进制全静态，不依赖任何动态库，所以
+Dockerfile里面又要下载muslc的静态库.a文件之类的，搞得很烦人。其实完全不必这么麻烦，都容器运行了，动态静态无所谓，所以可以考虑改天优化掉。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     - "26656-26657:26656-26657"
     volumes:
     - ./build:/home
-    command: /bin/bash -c 'cd /home/nodecluster/node0 && irita start --home irita'
+    command: /bin/bash -c 'cd /home/nodecluster/node0 && irita start --home irita 2>&1 | tee out.log'
     networks:
       localnet:
         ipv4_address: 192.168.10.2
@@ -20,7 +20,7 @@ services:
     - "26659-26660:26656-26657"
     volumes:
     - ./build:/home
-    command: /bin/bash -c 'cd /home/nodecluster/node1 && irita start --home irita'
+    command: /bin/bash -c 'cd /home/nodecluster/node1 && irita start --home irita 2>&1 | tee out.log'
     networks:
       localnet:
         ipv4_address: 192.168.10.3
@@ -32,7 +32,7 @@ services:
     - "26661-26662:26656-26657"
     volumes:
     - ./build:/home
-    command: /bin/bash -c 'cd /home/nodecluster/node2 && irita start --home irita'
+    command: /bin/bash -c 'cd /home/nodecluster/node2 && irita start --home irita 2>&1 | tee out.log'
     networks:
       localnet:
         ipv4_address: 192.168.10.4
@@ -44,7 +44,7 @@ services:
     - "26663-26664:26656-26657"
     volumes:
     - ./build:/home
-    command: /bin/bash -c 'cd /home/nodecluster/node3 && irita start --home irita'
+    command: /bin/bash -c 'cd /home/nodecluster/node3 && irita start --home irita 2>&1 | tee out.log'
     networks:
       localnet:
         ipv4_address: 192.168.10.5


### PR DESCRIPTION
之前用Docker compose运行4 validators的本地节点网络，节点内部的`crisis`模块的日志报出 `keeper.Keeper.AssetInvariants`的错误，

还提示:

```txt
CRITICAL please submit the following transaction:
   tx crisis invariant-borken bank total-supply
```

然后我发现了是SDK的这个模块的BUG，但是没追究其原因，我又看了下，感觉`go.mod`里面的sdk版本是包含了这些Fixs的

- https://github.com/cosmos/cosmos-sdk/issues/9159
- https://github.com/cosmos/cosmos-sdk/pull/9229
- https://github.com/cosmos/cosmos-sdk/issues/4795
- https://github.com/cosmos/cosmos-sdk/issues/4803
- https://github.com/cosmos/cosmos-sdk/pull/4854

但是我本机，不在容器里面编译就可以在ubuntu 20.04的环境里面运行，所以我把Dockerfile里面的golang版本和ubuntu的版本都升级到跟我本机编译开发环境保持一致，

最后运行docker compose的时候，节点就没有报错了，并且4个validators节点正常出块，并且同一高度的block的hash是一致的。

其实Dockerfile还可以优化，直接把golang的alpine Linux版本删除，在ubuntu上构建项目，他们文昌链为什么会这样做，用Alpine Linux编译，然后拷贝到ubuntu上，是因为golang的官方Docker镜像就是推荐用Alpine Linux的镜像版本，而且他们想用musl编译项目，让irita的二进制全静态，不依赖任何动态库，所以Dockerfile里面又要下载muslc的静态库.a文件之类的，搞得很烦人。

其实完全不必这么麻烦，都容器运行了，动态静态无所谓，所以可以考虑改天优化掉。